### PR TITLE
removed Travis deprecated filed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
-sudo: false
+dist: bionic
+
 language: node_js
 node_js:
-  - "8.3"
+  - node  # use the latest version
+
+jobs:
+  include:
+    - stage: 'Tests'
+      name: 'Static Linting'
+      script: npm run lint
+
+    - name: 'Unit Tests'
+      script: npm test
+
 notifications:
   disabled: true


### PR DESCRIPTION
Refer to https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration.

> In the next phase of the migration, all builds will run on virtual-machine-based infrastructure – regardless of the configuration for `sudo` in the `.travis.yml`.

> Soon we will run all projects on the virtual-machine-based infrastructure, the sudo keyword will be fully deprecated.